### PR TITLE
FIX: Release cell when is no visible anymore

### DIFF
--- a/HackrNewsiOS/Stories UI/Controllers/LiveHackrNewCellController.swift
+++ b/HackrNewsiOS/Stories UI/Controllers/LiveHackrNewCellController.swift
@@ -29,6 +29,7 @@ public final class LiveHackrNewCellController: StoryView, StoryLoadingView, Stor
     }
 
     func cancelLoad() {
+        releaseCellForReuse()
         delegate.didCancelRequest()
     }
 
@@ -52,5 +53,9 @@ public final class LiveHackrNewCellController: StoryView, StoryLoadingView, Stor
     public func display(_ viewModel: StoryErrorViewModel) {
         cell?.retryLoadStoryButton.isHidden = (viewModel.message == nil)
         cell?.container.isHidden = !(viewModel.message == nil)
+    }
+
+    private func releaseCellForReuse() {
+        cell = nil
     }
 }

--- a/HackrNewsiOSTests/Live Hackr News/Helpers/LiveHackrNewsViewController+TestHelpers.swift
+++ b/HackrNewsiOSTests/Live Hackr News/Helpers/LiveHackrNewsViewController+TestHelpers.swift
@@ -43,11 +43,13 @@ extension LiveHackrNewsViewController {
         liveHackrNewView(for: index) as? LiveHackrNewCell
     }
 
-    func simulateStoryViewNotVisible(at index: Int) {
+    @discardableResult
+    func simulateStoryViewNotVisible(at index: Int) -> LiveHackrNewCell? {
         let view = simulateStoryViewVisible(at: index)
         let delegate = tableView.delegate
         let indexPath = IndexPath(row: index, section: hackrNewsSection)
         delegate?.tableView?(tableView, didEndDisplaying: view!, forRowAt: indexPath)
+        return view
     }
 
     var hackrNewsSection: Int { 0 }

--- a/HackrNewsiOSTests/Live Hackr News/LiveHackrNewsViewControllerTests.swift
+++ b/HackrNewsiOSTests/Live Hackr News/LiveHackrNewsViewControllerTests.swift
@@ -260,6 +260,24 @@ final class LiveHackrNewsViewControllerTests: XCTestCase {
         )
     }
 
+    func test_storyView_doesNotRenderStoryContentWhenNotVisibleAnymore() {
+        let (sut, loader) = makeSUT()
+        let lhn0 = makeLiveHackrNew(id: 0)
+        let story0 = makeStory().model
+
+        sut.loadViewIfNeeded()
+        loader.completeLiveHackrNewsLoading(with: [lhn0.model], at: 0)
+        let view = sut.simulateStoryViewNotVisible(at: 0)
+
+        loader.completeStoryLoading(with: story0, at: 0)
+
+        XCTAssertNil(view?.titleLabel.text)
+        XCTAssertNil(view?.authorLabel.text)
+        XCTAssertNil(view?.scoreLabel.text)
+        XCTAssertNil(view?.createdAtLabel.text)
+        XCTAssertNil(view?.commentsLabel.text)
+    }
+
     // MARK: - Helpers
 
     private func makeSUT(
@@ -294,7 +312,7 @@ final class LiveHackrNewsViewControllerTests: XCTestCase {
         comments: [Int] = [],
         type: String = "",
         url: URL = URL(string: "https://any-url.com")!
-    ) -> (Story, StoryViewModel) {
+    ) -> (model: Story, viewModel: StoryViewModel) {
         let model = Story(
             id: id,
             title: title,


### PR DESCRIPTION
* By this way, we cancel request an release cell to avoid multiple controllers are using the same cell at same time.