### PR TITLE
UIKit Threading decorator

### DIFF
--- a/HackrNews.xcodeproj/project.pbxproj
+++ b/HackrNews.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3823131F259285CB0053274E /* MainQueueDispatchDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3823131E259285CB0053274E /* MainQueueDispatchDecorator.swift */; };
 		386551AC25868EF2002054AA /* HackrNewsiOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 386551A325868EF1002054AA /* HackrNewsiOS.framework */; };
 		386551C925869FD2002054AA /* LiveHackrNewsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386551C825869FD2002054AA /* LiveHackrNewsViewControllerTests.swift */; };
 		386551CE2586A5DB002054AA /* XCTestCase+MemoryLeaksTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D392AE2582DADC00FCAF70 /* XCTestCase+MemoryLeaksTracking.swift */; };
@@ -110,6 +111,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3823131E259285CB0053274E /* MainQueueDispatchDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainQueueDispatchDecorator.swift; sourceTree = "<group>"; };
 		386551A325868EF1002054AA /* HackrNewsiOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HackrNewsiOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		386551A625868EF1002054AA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		386551AB25868EF2002054AA /* HackrNewsiOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HackrNewsiOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -245,6 +247,7 @@
 			children = (
 				38E3CFFB258C155E00469872 /* WeakRefVirtualProxy.swift */,
 				38699B052588836F002B460B /* LiveHackrNewsUIComposer.swift */,
+				3823131E259285CB0053274E /* MainQueueDispatchDecorator.swift */,
 			);
 			path = Composers;
 			sourceTree = "<group>";
@@ -719,6 +722,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3823131F259285CB0053274E /* MainQueueDispatchDecorator.swift in Sources */,
 				38699AFB258865B6002B460B /* LiveHackrNewsRefreshController.swift in Sources */,
 				38699B002588774E002B460B /* LiveHackrNewCellController.swift in Sources */,
 				38699B062588836F002B460B /* LiveHackrNewsUIComposer.swift in Sources */,

--- a/HackrNewsiOS/Stories UI/Composers/LiveHackrNewsUIComposer.swift
+++ b/HackrNewsiOS/Stories UI/Composers/LiveHackrNewsUIComposer.swift
@@ -18,45 +18,16 @@ public final class LiveHackrNewsUIComposer {
         let refreshController = LiveHackrNewsRefreshController(delegate: presentationAdapter)
         let viewController = LiveHackrNewsViewController(refreshController: refreshController)
         presentationAdapter.presenter = LiveHackrNewsPresenter(
-            view: LiveHackrNewsViewAdapter(loader: MainQueueDispatchDecorator(hackrStoryLoader), controller: viewController, locale: locale, calendar: calendar),
+            view: LiveHackrNewsViewAdapter(
+                loader: MainQueueDispatchDecorator(hackrStoryLoader),
+                controller: viewController,
+                locale: locale,
+                calendar: calendar
+            ),
             loadingView: WeakRefVirtualProxy(refreshController),
             errorView: WeakRefVirtualProxy(viewController)
         )
         return viewController
-    }
-}
-
-final class MainQueueDispatchDecorator<T> {
-    private let decoratee: T
-    
-    init(_ decoratee: T) {
-        self.decoratee = decoratee
-    }
-    
-    func dispatch(completion: @escaping () -> Void) {
-        if Thread.isMainThread {
-            completion()
-        } else {
-            DispatchQueue.main.async {
-                completion()
-            }
-        }
-    }
-}
-
-extension MainQueueDispatchDecorator: LiveHackrNewsLoader where T == LiveHackrNewsLoader {
-    func load(completion: @escaping (LiveHackrNewsLoader.Result) -> Void) {
-        decoratee.load { [weak self] result in
-            self?.dispatch { completion(result) }
-        }
-    }
-}
-
-extension MainQueueDispatchDecorator: HackrStoryLoader where T == HackrStoryLoader {
-    func load(from url: URL, completion: @escaping (HackrStoryLoader.Result) -> Void) -> HackrStoryLoaderTask {
-        self.decoratee.load(from: url) {[weak self] result in
-            self?.dispatch { completion(result) }
-        }
     }
 }
 

--- a/HackrNewsiOS/Stories UI/Composers/LiveHackrNewsUIComposer.swift
+++ b/HackrNewsiOS/Stories UI/Composers/LiveHackrNewsUIComposer.swift
@@ -18,7 +18,7 @@ public final class LiveHackrNewsUIComposer {
         let refreshController = LiveHackrNewsRefreshController(delegate: presentationAdapter)
         let viewController = LiveHackrNewsViewController(refreshController: refreshController)
         presentationAdapter.presenter = LiveHackrNewsPresenter(
-            view: LiveHackrNewsViewAdapter(loader: hackrStoryLoader, controller: viewController, locale: locale, calendar: calendar),
+            view: LiveHackrNewsViewAdapter(loader: MainQueueDispatchDecorator(hackrStoryLoader), controller: viewController, locale: locale, calendar: calendar),
             loadingView: WeakRefVirtualProxy(refreshController),
             errorView: WeakRefVirtualProxy(viewController)
         )
@@ -26,22 +26,36 @@ public final class LiveHackrNewsUIComposer {
     }
 }
 
-final class MainQueueDispatchDecorator: LiveHackrNewsLoader {
-    let decoratee: LiveHackrNewsLoader
+final class MainQueueDispatchDecorator<T> {
+    private let decoratee: T
     
-    init(_ decoratee: LiveHackrNewsLoader) {
+    init(_ decoratee: T) {
         self.decoratee = decoratee
     }
     
-    func load(completion: @escaping (LiveHackrNewsLoader.Result) -> Void) {
-        decoratee.load { result in
-            if Thread.isMainThread {
-                completion(result)
-            } else {
-                DispatchQueue.main.async {
-                    completion(result)
-                }
+    func dispatch(completion: @escaping () -> Void) {
+        if Thread.isMainThread {
+            completion()
+        } else {
+            DispatchQueue.main.async {
+                completion()
             }
+        }
+    }
+}
+
+extension MainQueueDispatchDecorator: LiveHackrNewsLoader where T == LiveHackrNewsLoader {
+    func load(completion: @escaping (LiveHackrNewsLoader.Result) -> Void) {
+        decoratee.load { [weak self] result in
+            self?.dispatch { completion(result) }
+        }
+    }
+}
+
+extension MainQueueDispatchDecorator: HackrStoryLoader where T == HackrStoryLoader {
+    func load(from url: URL, completion: @escaping (HackrStoryLoader.Result) -> Void) -> HackrStoryLoaderTask {
+        self.decoratee.load(from: url) {[weak self] result in
+            self?.dispatch { completion(result) }
         }
     }
 }

--- a/HackrNewsiOS/Stories UI/Composers/MainQueueDispatchDecorator.swift
+++ b/HackrNewsiOS/Stories UI/Composers/MainQueueDispatchDecorator.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright © 2020 Jesús Alfredo Hernández Alarcón. All rights reserved.
+//
+
+import Foundation
+import HackrNews
+
+final class MainQueueDispatchDecorator<T> {
+    private let decoratee: T
+
+    init(_ decoratee: T) {
+        self.decoratee = decoratee
+    }
+
+    func dispatch(completion: @escaping () -> Void) {
+        if Thread.isMainThread {
+            completion()
+        } else {
+            DispatchQueue.main.async {
+                completion()
+            }
+        }
+    }
+}
+
+extension MainQueueDispatchDecorator: LiveHackrNewsLoader where T == LiveHackrNewsLoader {
+    func load(completion: @escaping (LiveHackrNewsLoader.Result) -> Void) {
+        decoratee.load { [weak self] result in
+            self?.dispatch { completion(result) }
+        }
+    }
+}
+
+extension MainQueueDispatchDecorator: HackrStoryLoader where T == HackrStoryLoader {
+    func load(from url: URL, completion: @escaping (HackrStoryLoader.Result) -> Void) -> HackrStoryLoaderTask {
+        decoratee.load(from: url) { [weak self] result in
+            self?.dispatch { completion(result) }
+        }
+    }
+}

--- a/HackrNewsiOS/Stories UI/Composers/MainQueueDispatchDecorator.swift
+++ b/HackrNewsiOS/Stories UI/Composers/MainQueueDispatchDecorator.swift
@@ -13,13 +13,10 @@ final class MainQueueDispatchDecorator<T> {
     }
 
     func dispatch(completion: @escaping () -> Void) {
-        if Thread.isMainThread {
-            completion()
-        } else {
-            DispatchQueue.main.async {
-                completion()
-            }
+        guard Thread.isMainThread else {
+            return DispatchQueue.main.async(execute: completion)
         }
+        completion()
     }
 }
 

--- a/HackrNewsiOSTests/Live Hackr News/LiveHackrNewsViewControllerTests.swift
+++ b/HackrNewsiOSTests/Live Hackr News/LiveHackrNewsViewControllerTests.swift
@@ -289,6 +289,23 @@ final class LiveHackrNewsViewControllerTests: XCTestCase {
         }
         wait(for: [exp], timeout: 1.0)
     }
+    
+    func test_loadLiveHackrNewsCompletion_dispatchesStoryLoaderFromBackgroundToMainThread() {
+        let (sut, loader) = makeSUT()
+        let lhn0 = makeLiveHackrNew(id: 0).model
+        let story0 = makeStory().model
+        sut.loadViewIfNeeded()
+        
+        loader.completeLiveHackrNewsLoading(with: [lhn0], at: 0)
+        sut.simulateStoryViewVisible(at: 0)
+        
+        let exp = expectation(description: "Wait for loader completion")
+        DispatchQueue.global().async {
+            loader.completeStoryLoading(with: story0, at: 0)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
 
     // MARK: - Helpers
 

--- a/HackrNewsiOSTests/Live Hackr News/LiveHackrNewsViewControllerTests.swift
+++ b/HackrNewsiOSTests/Live Hackr News/LiveHackrNewsViewControllerTests.swift
@@ -277,6 +277,18 @@ final class LiveHackrNewsViewControllerTests: XCTestCase {
         XCTAssertNil(view?.createdAtLabel.text)
         XCTAssertNil(view?.commentsLabel.text)
     }
+    
+    func test_loadLiveHackrNewsCompletion_dispatchesFromBackgroundToMainThread() {
+        let (sut, loader) = makeSUT()
+        sut.loadViewIfNeeded()
+        
+        let exp = expectation(description: "Wait for loader completion")
+        DispatchQueue.global().async {
+            loader.completeLiveHackrNewsLoading()
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
 
     // MARK: - Helpers
 

--- a/HackrNewsiOSTests/Live Hackr News/LiveHackrNewsViewControllerTests.swift
+++ b/HackrNewsiOSTests/Live Hackr News/LiveHackrNewsViewControllerTests.swift
@@ -277,11 +277,11 @@ final class LiveHackrNewsViewControllerTests: XCTestCase {
         XCTAssertNil(view?.createdAtLabel.text)
         XCTAssertNil(view?.commentsLabel.text)
     }
-    
+
     func test_loadLiveHackrNewsCompletion_dispatchesFromBackgroundToMainThread() {
         let (sut, loader) = makeSUT()
         sut.loadViewIfNeeded()
-        
+
         let exp = expectation(description: "Wait for loader completion")
         DispatchQueue.global().async {
             loader.completeLiveHackrNewsLoading()
@@ -289,16 +289,16 @@ final class LiveHackrNewsViewControllerTests: XCTestCase {
         }
         wait(for: [exp], timeout: 1.0)
     }
-    
+
     func test_loadLiveHackrNewsCompletion_dispatchesStoryLoaderFromBackgroundToMainThread() {
         let (sut, loader) = makeSUT()
         let lhn0 = makeLiveHackrNew(id: 0).model
         let story0 = makeStory().model
         sut.loadViewIfNeeded()
-        
+
         loader.completeLiveHackrNewsLoading(with: [lhn0], at: 0)
         sut.simulateStoryViewVisible(at: 0)
-        
+
         let exp = expectation(description: "Wait for loader completion")
         DispatchQueue.global().async {
             loader.completeStoryLoading(with: story0, at: 0)


### PR DESCRIPTION
Implemented threading strategy to prevent UI updates outside the main queue using the Decorator pattern. This way, the UI is agnostic of threading logic/details.

_Threading is dealt with in the Composition layer._