### PR TITLE
FIX: Preloading comments

### DIFF
--- a/HackrNewsApp/HackrNewsAppTests/Story Details/StoryDetailsUIIntegrationTests.swift
+++ b/HackrNewsApp/HackrNewsAppTests/Story Details/StoryDetailsUIIntegrationTests.swift
@@ -161,6 +161,16 @@ final class StoryDetailsUIIntegrationTests: XCTestCase {
         XCTAssertEqual(loader.loadCallCount, 2)
     }
 
+    func test_storyHasNotComments_preventsPreloadComment() {
+        let story = makeStoryDetail(comments: [])
+        let (sut, loader) = makeSUT(story: story)
+
+        sut.loadViewIfNeeded()
+
+        sut.simulateCommentViewIsNearVisible(at: 0)
+        XCTAssertEqual(loader.loadCallCount, 0)
+    }
+
     func test_commentView_cancelsPreloadingCommentWhenIsNotNearVisibleAnymore() {
         let story = makeStoryDetail(comments: [1])
         let (sut, loader) = makeSUT(story: story)
@@ -173,6 +183,16 @@ final class StoryDetailsUIIntegrationTests: XCTestCase {
 
         sut.simulateCommentViewIsNotNearVisible(at: 0)
         XCTAssertEqual(loader.cancelledRequests, 1)
+    }
+
+    func test_storyHasNotComments_preventsCancelComment() {
+        let story = makeStoryDetail(comments: [])
+        let (sut, loader) = makeSUT(story: story)
+
+        sut.loadViewIfNeeded()
+
+        sut.simulateCommentViewIsNotNearVisible(at: 0)
+        XCTAssertEqual(loader.cancelledRequests, 0)
     }
 
     func test_loadComment_cancelsLoadingCommentWhenViewNotVisibleAnymore() {

--- a/HackrNewsiOS/Story Details UI/Controllers/StoryDetailsViewController.swift
+++ b/HackrNewsiOS/Story Details UI/Controllers/StoryDetailsViewController.swift
@@ -87,13 +87,17 @@ public class StoryDetailsViewController: UITableViewController, UITableViewDataS
 
     public func tableView(_: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
         indexPaths.forEach { indexPath in
-            comments[indexPath.row].preload()
+            if indexPath.section == commentsSection, comments.count > 0 {
+                comments[indexPath.row].preload()
+            }
         }
     }
 
     public func tableView(_: UITableView, cancelPrefetchingForRowsAt indexPaths: [IndexPath]) {
         indexPaths.forEach { indexPath in
-            comments[indexPath.row].cancel()
+            if indexPath.section == commentsSection, comments.count > 0 {
+                comments[indexPath.row].cancel()
+            }
         }
     }
 

--- a/HackrNewsiOS/Story Details UI/Controllers/StoryDetailsViewController.swift
+++ b/HackrNewsiOS/Story Details UI/Controllers/StoryDetailsViewController.swift
@@ -75,7 +75,7 @@ public class StoryDetailsViewController: UITableViewController, UITableViewDataS
         case storySection:
             storyCellController.releaseCellForReuse()
         case commentsSection:
-            comments[indexPath.row].cancel()
+            cancelComment(at: indexPath)
         default:
             break
         }
@@ -87,7 +87,7 @@ public class StoryDetailsViewController: UITableViewController, UITableViewDataS
 
     public func tableView(_: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
         indexPaths.forEach { indexPath in
-            if indexPath.section == commentsSection, comments.count > 0 {
+            if areValidComments(at: indexPath) {
                 comments[indexPath.row].preload()
             }
         }
@@ -95,9 +95,17 @@ public class StoryDetailsViewController: UITableViewController, UITableViewDataS
 
     public func tableView(_: UITableView, cancelPrefetchingForRowsAt indexPaths: [IndexPath]) {
         indexPaths.forEach { indexPath in
-            if indexPath.section == commentsSection, comments.count > 0 {
-                comments[indexPath.row].cancel()
-            }
+            cancelComment(at: indexPath)
+        }
+    }
+
+    private func areValidComments(at indexPath: IndexPath) -> Bool {
+        (indexPath.section == commentsSection) && (comments.count > 0)
+    }
+
+    private func cancelComment(at indexPath: IndexPath) {
+        if areValidComments(at: indexPath) {
+            comments[indexPath.row].cancel()
         }
     }
 


### PR DESCRIPTION
By validating number of comments is greater than zero, we avoid app crashes on pre-load and pre-cancel (prefetch/ cancelprefetching)