### PR TITLE
Feed: Scroll to top fix

### DIFF
--- a/HackrNewsApp/HackrNewsApp/App/SceneDelegate.swift
+++ b/HackrNewsApp/HackrNewsApp/App/SceneDelegate.swift
@@ -114,7 +114,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 extension SceneDelegate: UITabBarControllerDelegate {
     func tabBarController(_: UITabBarController, didSelect viewController: UIViewController) {
-        if previousViewController == (viewController as? UINavigationController)?.topViewController as? HackrNewsFeedViewController {
+        if previousViewController == (viewController as? UINavigationController)?.topViewController {
             if let viewController = (viewController as? UINavigationController)?.topViewController as? HackrNewsFeedViewController {
                 viewController.scrollToTop()
             }
@@ -122,8 +122,8 @@ extension SceneDelegate: UITabBarControllerDelegate {
         previousViewController = viewController
     }
 
-    func tabBarController(_: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
-        previousViewController = (viewController as? UINavigationController)?.topViewController
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect _: UIViewController) -> Bool {
+        previousViewController = (tabBarController.selectedViewController as? UINavigationController)?.topViewController
         return true
     }
 }

--- a/HackrNewsApp/HackrNewsApp/App/SceneDelegate.swift
+++ b/HackrNewsApp/HackrNewsApp/App/SceneDelegate.swift
@@ -114,8 +114,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 extension SceneDelegate: UITabBarControllerDelegate {
     func tabBarController(_: UITabBarController, didSelect viewController: UIViewController) {
-        if previousViewController == (viewController as? UINavigationController)?.topViewController {
-            if let viewController = (viewController as? UINavigationController)?.topViewController as? HackrNewsFeedViewController {
+        let topViewController = (viewController as? UINavigationController)?.topViewController
+        if previousViewController == topViewController {
+            if let viewController = topViewController as? HackrNewsFeedViewController {
                 viewController.scrollToTop()
             }
         }

--- a/HackrNewsApp/HackrNewsAppTests/Feed/Helpers/HackrNewsFeedViewController+TestHelpers.swift
+++ b/HackrNewsApp/HackrNewsAppTests/Feed/Helpers/HackrNewsFeedViewController+TestHelpers.swift
@@ -61,6 +61,6 @@ extension HackrNewsFeedViewController {
     var hackrNewsSection: Int { 0 }
 
     var isDisplayingTopContent: Bool {
-        tableView.contentOffset.y == 0
+        !(tableView.contentOffset.y > (-tableView.adjustedContentInset.top))
     }
 }

--- a/HackrNewsApp/HackrNewsAppTests/Hackr News Acceptance Tests/HackrNewsAppAcceptanceTests.swift
+++ b/HackrNewsApp/HackrNewsAppTests/Hackr News Acceptance Tests/HackrNewsAppAcceptanceTests.swift
@@ -102,7 +102,7 @@ final class HackrNewsAppAcceptanceTests: XCTestCase {
         let app = launch(httpClient: .online(response))
 
         app.simulateScrollDown(at: 4)
-        XCTAssertFalse(app.isDisplayingTopContent, "Shold not display top content after scroll down")
+        XCTAssertFalse(app.isDisplayingTopContent, "Should not display top content after scroll down")
 
         app.simulateTapOnTabItem()
         XCTAssertTrue(app.isDisplayingTopContent, "Should display top content after tap on tabbar item")

--- a/HackrNewsApp/HackrNewsAppTests/Hackr News Acceptance Tests/HackrNewsAppAcceptanceTests.swift
+++ b/HackrNewsApp/HackrNewsAppTests/Hackr News Acceptance Tests/HackrNewsAppAcceptanceTests.swift
@@ -102,11 +102,19 @@ final class HackrNewsAppAcceptanceTests: XCTestCase {
         let app = launch(httpClient: .online(response))
 
         app.simulateScrollDown(at: 4)
-        XCTAssertFalse(app.isDisplayingTopContent)
+        XCTAssertFalse(app.isDisplayingTopContent, "Shold not display top content after scroll down")
 
         app.simulateTapOnTabItem()
+        XCTAssertTrue(app.isDisplayingTopContent, "Should display top content after tap on tabbar item")
+
+        app.simulateScrollDown(at: 4)
+        app.simulateTapOnBestStories()
+        app.simulateTapOnStory(at: 0)
+        app.simulateTapOnTopStories()
+        XCTAssertFalse(app.isDisplayingTopContent, "Should not display top content after displaying story details")
+
         app.simulateTapOnTabItem()
-        XCTAssertTrue(app.isDisplayingTopContent)
+        XCTAssertTrue(app.isDisplayingTopContent, "Should display top content after tap on tabbar item")
     }
 
     // MARK: - Helpers

--- a/HackrNewsApp/HackrNewsAppTests/Hackr News Acceptance Tests/Helpers/HackrNewsFeedViewController+Events.swift
+++ b/HackrNewsApp/HackrNewsAppTests/Hackr News Acceptance Tests/Helpers/HackrNewsFeedViewController+Events.swift
@@ -12,6 +12,7 @@ extension HackrNewsFeedViewController {
         return tabBarController!.selectedViewController
     }
 
+    @discardableResult
     func simulateTapOnTopStories() -> HackrNewsFeedViewController {
         let navigation = simulateTap(at: topStoriesTab) as! UINavigationController
         return navigation.topViewController as! HackrNewsFeedViewController
@@ -22,6 +23,7 @@ extension HackrNewsFeedViewController {
         return navigation.topViewController as! HackrNewsFeedViewController
     }
 
+    @discardableResult
     func simulateTapOnBestStories() -> HackrNewsFeedViewController {
         let navigation = simulateTap(at: bestStoriesTab) as! UINavigationController
         return navigation.topViewController as! HackrNewsFeedViewController

--- a/HackrNewsApp/HackrNewsAppTests/Hackr News Acceptance Tests/Helpers/UITabBarController+Events.swift
+++ b/HackrNewsApp/HackrNewsAppTests/Hackr News Acceptance Tests/Helpers/UITabBarController+Events.swift
@@ -13,7 +13,8 @@ extension UITabBarController {
     }
 
     func simulateTap(at controller: UIViewController) {
-        _ = delegate?.tabBarController?(self, shouldSelect: controller)
+        let anyController = UIViewController()
+        _ = delegate?.tabBarController?(self, shouldSelect: anyController)
         delegate?.tabBarController?(self, didSelect: controller)
     }
 }

--- a/HackrNewsiOS/Hacker News Feed UI/Controllers/HackrNewsFeedViewController.swift
+++ b/HackrNewsiOS/Hacker News Feed UI/Controllers/HackrNewsFeedViewController.swift
@@ -76,8 +76,8 @@ public class HackrNewsFeedViewController: UITableViewController, UITableViewData
     }
 
     public func scrollToTop() {
-        if tableModel.count > 0 {
-            tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
+        if tableView.contentOffset.y > (-tableView.adjustedContentInset.top) {
+            fixNavigationBarSize(afterRefresh: false)
         }
     }
 }


### PR DESCRIPTION
Prevents after displaying story details and return back to feed, doesn't display content at top.